### PR TITLE
Modernize plugin registration vars

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -466,7 +466,8 @@ extern "C"
 
   extern const char plugin_name[] = "singularity-exec";
   extern const char plugin_type[] = "spank";
-  extern const unsigned int plugin_version = 0;
+  extern const unsigned int plugin_version = SLURM_VERSION_NUMBER;
+  extern const unsigned int spank_plugin_version = 0;
 }
 
 // vim: foldmethod=marker foldmarker={,} sw=2 et


### PR DESCRIPTION
see https://github.com/SchedMD/slurm/commit/db697131b0350f74b90a37259a1c583e8475ea95

---

@michaelmayer2 Thank you very much for contributing this patch! I took the liberty and kept the type of `plugin_version` as `unsigned int` to match [the registration macro in `<slurm/spank.h>`](https://github.com/SchedMD/slurm/blob/9217152b6049af70bbddaee4615a17ec05437a35/slurm/spank.h#L443-L447). Let me know, if you have any objections.

Besides that, we have decided to move the repo to github to simplify future collaboration. Over the course of the next days or so I will also add some CI actions and fix the broken links in the readme file.