### PR TITLE
Use APPTAINERENV_PREPEND_PATH while launching a container.

### DIFF
--- a/slurm-singularity-wrapper.sh
+++ b/slurm-singularity-wrapper.sh
@@ -35,7 +35,7 @@ run_in() {
         # export the PATH and LD_LIBRARY_PATH environment variable to the container
         #export SINGULARITYENV_PATH=$PATH
         #export SINGULARITYENV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-        export APPTAINERENV_PATH=$PATH
+        export APPTAINERENV_PREPEND_PATH=$PATH
         export APPTAINERENV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
         echo "Start container image $container"


### PR DESCRIPTION
Prepend the PATH in a container instead of overwriting it.